### PR TITLE
Use `split_windows_volume_prefix()` in `split_windows()` and new `is_absolute_windows()`.

### DIFF
--- a/src/filepath.gleam
+++ b/src/filepath.gleam
@@ -375,8 +375,13 @@ fn get_directory_name(
   }
 }
 
-// TODO: windows support
-/// Check if a path is absolute.
+/// Check whether a given path counts as an absolute path on the
+/// operating system which it's currently being run on.
+///
+/// On Unix systems, absolute paths start with a `/`.
+///
+/// On Windows systems, absolute paths must contain a volume prefix
+/// as dictated by the `split_windows_volume_prefix()` function.
 ///
 /// ## Examples
 ///
@@ -391,7 +396,52 @@ fn get_directory_name(
 /// ```
 ///
 pub fn is_absolute(path: String) -> Bool {
+  case is_windows() {
+    True -> is_absolute_windows(path)
+    False -> is_absolute_unix(path)
+  }
+}
+
+/// Check whether a given Unix path is absolute.
+///
+/// ## Examples
+///
+/// ```gleam
+/// is_absolute_unix("/usr/local/bin")
+/// // -> True
+/// ```
+///
+/// ```gleam
+/// is_absolute_unix("usr/local/bin")
+/// // -> False
+/// ```
+///
+pub fn is_absolute_unix(path: String) -> Bool {
   string.starts_with(path, "/")
+}
+
+/// Check whether a given Windows path is absolute.
+///
+/// Paths on Windows only count as absolute if they have a proper volume
+/// specifier as a prefix, as dictated by `split_windows_volume_prefix()`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// is_absolute_windows("C:\\dir1\\dir2\\file.txt")
+/// // -> True
+/// ```
+///
+/// ```gleam
+/// is_absolute_windows("\\dir1\\dir2\\file.txt")
+/// // -> False
+/// ```
+///
+pub fn is_absolute_windows(path: String) -> Bool {
+  case split_windows_volume_prefix(path) {
+    #("", _) -> False
+    _ -> True
+  }
 }
 
 //TODO: windows support

--- a/test/filepath_test.gleam
+++ b/test/filepath_test.gleam
@@ -392,38 +392,78 @@ pub fn directory_name_7_test() {
   |> should.equal("one/two/three")
 }
 
-pub fn is_absolute_0_test() {
-  filepath.is_absolute("")
+pub fn is_absolute_unix_0_test() {
+  filepath.is_absolute_unix("")
   |> should.equal(False)
 }
 
-pub fn is_absolute_1_test() {
-  filepath.is_absolute("file")
+pub fn is_absolute_unix_1_test() {
+  filepath.is_absolute_unix("file")
   |> should.equal(False)
 }
 
-pub fn is_absolute_2_test() {
-  filepath.is_absolute("/usr/local/bin")
+pub fn is_absolute_unix_2_test() {
+  filepath.is_absolute_unix("/usr/local/bin")
   |> should.equal(True)
 }
 
-pub fn is_absolute_3_test() {
-  filepath.is_absolute("usr/local/bin")
+pub fn is_absolute_unix_3_test() {
+  filepath.is_absolute_unix("usr/local/bin")
   |> should.equal(False)
 }
 
-pub fn is_absolute_4_test() {
-  filepath.is_absolute("../usr/local/bin")
+pub fn is_absolute_unix_4_test() {
+  filepath.is_absolute_unix("../usr/local/bin")
   |> should.equal(False)
 }
 
-pub fn is_absolute_5_test() {
-  filepath.is_absolute("./usr/local/bin")
+pub fn is_absolute_unix_5_test() {
+  filepath.is_absolute_unix("./usr/local/bin")
   |> should.equal(False)
 }
 
-pub fn is_absolute_6_test() {
-  filepath.is_absolute("/")
+pub fn is_absolute_unix_6_test() {
+  filepath.is_absolute_unix("/")
+  |> should.equal(True)
+}
+
+pub fn is_absolute_windows_0_test() {
+  filepath.is_absolute_windows("")
+  |> should.equal(False)
+}
+
+pub fn is_absolute_windows_1_test() {
+  filepath.is_absolute_windows("\\")
+  |> should.equal(False)
+}
+
+pub fn is_absolute_windows_2_test() {
+  filepath.is_absolute_windows("/")
+  |> should.equal(False)
+}
+
+pub fn is_absolute_windows_3_test() {
+  filepath.is_absolute_windows("")
+  |> should.equal(False)
+}
+
+pub fn is_absolute_windows_4_test() {
+  filepath.is_absolute_windows("C:\\Program Files")
+  |> should.equal(True)
+}
+
+pub fn is_absolute_windows_5_test() {
+  filepath.is_absolute_windows("C:/Program Files")
+  |> should.equal(True)
+}
+
+pub fn is_absolute_windows_6_test() {
+  filepath.is_absolute_windows("\\\\DESKTOP-123\\MyShare\\subdir\\file.txt")
+  |> should.equal(True)
+}
+
+pub fn is_absolute_windows_7_test() {
+  filepath.is_absolute_windows("//DESKTOP-123/MyShare/subdir/file.txt")
   |> should.equal(True)
 }
 

--- a/test/filepath_test.gleam
+++ b/test/filepath_test.gleam
@@ -91,12 +91,12 @@ pub fn split_windows_2_test() {
 
 pub fn split_windows_3_test() {
   filepath.split_windows("C:\\one\\two")
-  |> should.equal(["c:/", "one", "two"])
+  |> should.equal(["C:", "one", "two"])
 }
 
 pub fn split_windows_4_test() {
   filepath.split_windows("C:/one/two")
-  |> should.equal(["c:/", "one", "two"])
+  |> should.equal(["C:", "one", "two"])
 }
 
 pub fn split_windows_5_test() {

--- a/test/filepath_test.gleam
+++ b/test/filepath_test.gleam
@@ -1,6 +1,5 @@
 import gleam/list
 import gleam/string
-
 import filepath
 import gleeunit
 import gleeunit/should
@@ -111,141 +110,131 @@ pub fn split_windows_6_test() {
 }
 
 pub fn split_windows_volume_prefix_multi_test() {
-    let testfn = fn(testcase: #(String, #(String, String))) {
-        let #(path, expected_split) = testcase
+  let testfn = fn(testcase: #(String, #(String, String))) {
+    let #(path, expected_split) = testcase
 
-        // Run test case as provided:
-        filepath.split_windows_volume_prefix(path)
-        |> should.equal(expected_split)
+    // Run test case as provided:
+    filepath.split_windows_volume_prefix(path)
+    |> should.equal(expected_split)
 
-        // Invert path separators in test case and expected and re-test:
-        let #(current_separator, other_separator) = case string.contains(path, "/") {
-            True -> #("/", "\\")
-            False -> #("\\", "/")
-        }
-        let invert_separator_char = fn(c) {
-            case c {
-                c if c == current_separator -> other_separator
-                c if c == other_separator -> current_separator
-                c -> c
-            }
-        }
-        let invert_separators = fn(s) {
-            s
-            |> string.to_graphemes
-            |> list.map(invert_separator_char)
-            |> string.join("")
-        }
-
-        let #(expected_volume, expected_rest) = expected_split
-        path
-        |> invert_separators
-        |> filepath.split_windows_volume_prefix
-        |> should.equal(
-            #(invert_separators(expected_volume),
-              invert_separators(expected_rest)))
+    // Invert path separators in test case and expected and re-test:
+    let #(current_separator, other_separator) = case
+      string.contains(path, "/")
+    {
+      True -> #("/", "\\")
+      False -> #("\\", "/")
+    }
+    let invert_separator_char = fn(c) {
+      case c {
+        c if c == current_separator -> other_separator
+        c if c == other_separator -> current_separator
+        c -> c
+      }
+    }
+    let invert_separators = fn(s) {
+      s
+      |> string.to_graphemes
+      |> list.map(invert_separator_char)
+      |> string.join("")
     }
 
-    let testcases: List(#(String, #(String, String))) = [
-        // Unix paths:
-        #("/", #("", "/")),
-        #("/usr/local/bin", #("", "/usr/local/bin")),
+    let #(expected_volume, expected_rest) = expected_split
+    path
+    |> invert_separators
+    |> filepath.split_windows_volume_prefix
+    |> should.equal(#(
+      invert_separators(expected_volume),
+      invert_separators(expected_rest),
+    ))
+  }
 
-        // Base Windows cases:
-        #("", #("", "")),
-        #("/", #("", "/")),
-        #("\\", #("", "\\")),
-        #("file", #("", "file")),
-        #("dir1/dir2/file.txt", #("", "dir1/dir2/file.txt")),
-        #("::/one/two", #("", "::/one/two")),
-        #("::\\one\\two", #("", "::\\one\\two")),
-        #("C:", #("C:", "")),
-        #("c:", #("c:", "")),
-        #("C:/", #("C:", "")),
-        #("c:\\", #("c:", "")),
-        #("C:/one/two", #("C:", "one/two")),
-        #("c:/one/two", #("c:", "one/two")),
-        #("C:\\one\\two", #("C:", "one\\two")),
-        #("c:\\one\\two", #("c:", "one\\two")),
-        #("C:\\one\\two/three", #("C:", "one\\two/three")),
-        #("c:/one/two\\three", #("c:", "one/two\\three")),
+  let testcases: List(#(String, #(String, String))) = [
+    // Unix paths:
+    #("/", #("", "/")),
+    #("/usr/local/bin", #("", "/usr/local/bin")),
+    // Base Windows cases:
+    #("", #("", "")),
+    #("/", #("", "/")),
+    #("\\", #("", "\\")),
+    #("file", #("", "file")),
+    #("dir1/dir2/file.txt", #("", "dir1/dir2/file.txt")),
+    #("::/one/two", #("", "::/one/two")),
+    #("::\\one\\two", #("", "::\\one\\two")),
+    #("C:", #("C:", "")),
+    #("c:", #("c:", "")),
+    #("C:/", #("C:", "")),
+    #("c:\\", #("c:", "")),
+    #("C:/one/two", #("C:", "one/two")),
+    #("c:/one/two", #("c:", "one/two")),
+    #("C:\\one\\two", #("C:", "one\\two")),
+    #("c:\\one\\two", #("c:", "one\\two")),
+    #("C:\\one\\two/three", #("C:", "one\\two/three")),
+    #("c:/one/two\\three", #("c:", "one/two\\three")),
+    // Current-drive absolute paths:
+    #("/dir1/dir2/file.txt", #("", "/dir1/dir2/file.txt")),
+    #("/dir1/dir2\\file.txt", #("", "/dir1/dir2\\file.txt")),
+    #("\\dir1\\dir2\\file.txt", #("", "\\dir1\\dir2\\file.txt")),
+    // Drive-relative paths:
+    #("C:dir1/dir2/file.txt", #("C:", "dir1/dir2/file.txt")),
+    #("C:dir1/dir2\\file.txt", #("C:", "dir1/dir2\\file.txt")),
+    #("C:dir1\\dir2\\file.txt", #("C:", "dir1\\dir2\\file.txt")),
+    // Specialized Windows paths:
+    #("HKLM:", #("HKLM:", "")),
+    #("HKLM:/", #("HKLM:", "")),
+    #("//./pipe", #("//./pipe", "")),
+    #("//./pipe/", #("//./pipe", "")),
+    #("//./pipe/testpipe", #("//./pipe", "testpipe")),
+    #("HKLM:/SOFTWARE/Microsoft/Windows/CurrentVersion", #(
+      "HKLM:",
+      "SOFTWARE/Microsoft/Windows/CurrentVersion",
+    )),
+    #("//./Volume{b75e2c83-0000-0000-0000-602f00000000}/Test/Foo.txt", #(
+      "//./Volume{b75e2c83-0000-0000-0000-602f00000000}",
+      "Test/Foo.txt",
+    )),
+    #("//LOCALHOST/c$/temp/test-file.txt", #(
+      "//LOCALHOST/c$",
+      "temp/test-file.txt",
+    )),
+    #("//./c:/temp/test-file.txt", #("//./c:", "temp/test-file.txt")),
+    #("//?/c:/temp/test-file.txt", #("//?/c:", "temp/test-file.txt")),
+    #("//./UNC/LOCALHOST/c$/temp/test-file.txt", #(
+      "//./UNC",
+      "LOCALHOST/c$/temp/test-file.txt",
+    )),
+    #("//?/UNC/LOCALHOST/c$/temp/test-file.txt", #(
+      "//?/UNC",
+      "LOCALHOST/c$/temp/test-file.txt",
+    )),
+    #("//127.0.0.1/c$/temp/test-file.txt", #(
+      "//127.0.0.1/c$",
+      "temp/test-file.txt",
+    )),
+    #("//DESKTOP-123/MyShare/subdir/file.txt", #(
+      "//DESKTOP-123/MyShare",
+      "subdir/file.txt",
+    )),
+    // Incomplete special paths which are interpreted as current-drive-relative:
+    #("//", #("", "//")),
+    #("//.", #("", "//.")),
+    #("//./", #("", "//./")),
+    // Incomplete special paths:
+    #("//?", #("", "//?")),
+    #("//?/", #("", "//?/")),
+    #("//.///", #("", "//.///")),
+    #("//?///", #("", "//?///")),
+    #("//127.0.0.1", #("", "//127.0.0.1")),
+    #("//127.0.0.1/", #("", "//127.0.0.1/")),
+    // Redundant slashes in special volume paths:
+    #("//./////pipe///testpipe", #("//./////pipe", "//testpipe")),
+    #("//?///////pipe///testpipe", #("//?///////pipe", "//testpipe")),
+    #("//127.0.0.1/////c$/temp/test-file.txt", #(
+      "//127.0.0.1/////c$",
+      "temp/test-file.txt",
+    )),
+  ]
 
-        // Current-drive absolute paths:
-        #("/dir1/dir2/file.txt", #("", "/dir1/dir2/file.txt")),
-        #("/dir1/dir2\\file.txt", #("", "/dir1/dir2\\file.txt")),
-        #("\\dir1\\dir2\\file.txt", #("", "\\dir1\\dir2\\file.txt")),
-
-        // Drive-relative paths:
-        #("C:dir1/dir2/file.txt", #("C:", "dir1/dir2/file.txt")),
-        #("C:dir1/dir2\\file.txt", #("C:", "dir1/dir2\\file.txt")),
-        #("C:dir1\\dir2\\file.txt", #("C:", "dir1\\dir2\\file.txt")),
-
-        // Specialized Windows paths:
-        #("HKLM:", #("HKLM:", "")),
-        #("HKLM:/", #("HKLM:", "")),
-        #("//./pipe", #("//./pipe", "")),
-        #("//./pipe/", #("//./pipe", "")),
-        #("//./pipe/testpipe", #("//./pipe", "testpipe")),
-        #(
-            "HKLM:/SOFTWARE/Microsoft/Windows/CurrentVersion",
-            #("HKLM:", "SOFTWARE/Microsoft/Windows/CurrentVersion")
-        ),
-        #(
-            "//./Volume{b75e2c83-0000-0000-0000-602f00000000}/Test/Foo.txt",
-            #("//./Volume{b75e2c83-0000-0000-0000-602f00000000}", "Test/Foo.txt")
-        ),
-        #(
-            "//LOCALHOST/c$/temp/test-file.txt",
-            #("//LOCALHOST/c$", "temp/test-file.txt")
-        ),
-        #(
-            "//./c:/temp/test-file.txt",
-            #("//./c:", "temp/test-file.txt")
-        ),
-        #(
-            "//?/c:/temp/test-file.txt",
-            #("//?/c:", "temp/test-file.txt")
-        ),
-        #(
-            "//./UNC/LOCALHOST/c$/temp/test-file.txt",
-            #("//./UNC", "LOCALHOST/c$/temp/test-file.txt")
-        ),
-        #(
-            "//?/UNC/LOCALHOST/c$/temp/test-file.txt",
-            #("//?/UNC", "LOCALHOST/c$/temp/test-file.txt")
-        ),
-        #(
-            "//127.0.0.1/c$/temp/test-file.txt",
-            #("//127.0.0.1/c$", "temp/test-file.txt")
-        ),
-        #(
-            "//DESKTOP-123/MyShare/subdir/file.txt",
-            #("//DESKTOP-123/MyShare", "subdir/file.txt")
-        ),
-
-        // Incomplete special paths which are interpreted as current-drive-relative:
-        #("//", #("", "//")),
-        #("//.", #("", "//.")),
-        #("//./", #("", "//./")),
-
-        // Incomplete special paths:
-        #("//?", #("", "//?")),
-        #("//?/", #("", "//?/")),
-        #("//.///", #("", "//.///")),
-        #("//?///", #("", "//?///")),
-        #("//127.0.0.1", #("", "//127.0.0.1")),
-        #("//127.0.0.1/", #("", "//127.0.0.1/")),
-
-        // Redundant slashes in special volume paths:
-        #("//./////pipe///testpipe", #("//./////pipe", "//testpipe")),
-        #("//?///////pipe///testpipe", #("//?///////pipe", "//testpipe")),
-        #(
-            "//127.0.0.1/////c$/temp/test-file.txt",
-            #("//127.0.0.1/////c$", "temp/test-file.txt")
-        ),
-    ]
-
-    list.map(testcases, testfn)
+  list.map(testcases, testfn)
 }
 
 pub fn join_0_test() {


### PR DESCRIPTION
WARN: this code may NOT run correctly on OTP because of this compiler bug: https://github.com/gleam-lang/gleam/issues/2733

Depends on (and includes) the changes in: https://github.com/lpil/filepath/pull/7

This patch adds a new `is_absolute_windows()` function and also switches `split_windows()` to use the new `split_windows_volume_prefix()` function.

BREAKING: Note that `split_windows()`(and by extension `split()` on Windows) will no longer auto-lowercase the drive letter, nor include the slash in the first drive element of the split as it used to.

~Most notable is the addition of the `split_windows_volume_prefix()` function for (hopefully) complete coverage of all possible Windows volume prefix formats.~

~This is mainly a side-effect of it being also converted to use the new `split_windows_volume_prefix()`, but IMO it should never had taken said steps to begin with, as these behaviors broke the expected tautology that: `path == string.join("/", split(path))` should always be true. (presuming the slash orientation is correct)~

PS: this is my first real Gleam language patch, so please be as harsh as necessary. 😄